### PR TITLE
Fixed WWW error handling

### DIFF
--- a/Assets/WebCamTextureToCloudVision.cs
+++ b/Assets/WebCamTextureToCloudVision.cs
@@ -270,7 +270,7 @@ public class WebCamTextureToCloudVision : MonoBehaviour {
 				byte[] postData = System.Text.Encoding.Default.GetBytes(jsonData);
 				using(WWW www = new WWW(url, postData, headers)) {
 					yield return www;
-					if (www.error == null) {
+					if (string.IsNullOrEmpty(www.error)) {
 						Debug.Log(www.text.Replace("\n", "").Replace(" ", ""));
 						AnnotateImageResponses responses = JsonUtility.FromJson<AnnotateImageResponses>(www.text);
 						// SendMessage, BroadcastMessage or someting like that.


### PR DESCRIPTION
From the documentation: https://docs.unity3d.com/ScriptReference/WWW-error.html

If there was no error, error will return null or an empty string (this is because some platforms don't allow nulls for string values). We recommend that you use String.IsNullOrEmpty to check for the presence of an error so that both cases are covered.